### PR TITLE
Add runtime metrics editor to example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:material_toolkit_example/notifiers/root_notifier.dart';
 import 'package:material_toolkit_example/notifiers/theme_notifier.dart';
 import 'package:material_toolkit_example/paiting/border_radius_circular_group.dart';
 import 'package:material_toolkit_example/widgets/group_card.dart';
+import 'package:material_toolkit_example/widgets/metrics_editor.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -112,6 +113,8 @@ class _RootState extends State<Root> {
                 style: textTheme.bodyMedium?.copyWith(color: colorScheme.error),
               ),
             ),
+            gaps.large,
+            const MetricsEditor(),
             LayoutBuilder(
               builder: (context, constraints) {
                 return ConstrainedBox(

--- a/example/lib/notifiers/theme_notifier.dart
+++ b/example/lib/notifiers/theme_notifier.dart
@@ -67,6 +67,54 @@ class ThemeNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates the spaces data and notifies listeners.
+  void updateSpacesData(XSpacesData newSpacesData) {
+    spaces = newSpacesData;
+    notifyListeners();
+  }
+
+  /// Updates the icon sizes data and notifies listeners.
+  void updateIconSizesData(XIconSizesData newIconSizesData) {
+    iconSizes = newIconSizesData;
+    notifyListeners();
+  }
+
+  /// Updates the elevations data and notifies listeners.
+  void updateElevationsData(XElevationsData newElevationsData) {
+    elevations = newElevationsData;
+    notifyListeners();
+  }
+
+  /// Updates the durations data and notifies listeners.
+  void updateDurationsData(XDurationsData newDurationsData) {
+    durations = newDurationsData;
+    notifyListeners();
+  }
+
+  /// Updates the breakpoints data and notifies listeners.
+  void updateBreakpointsData(XBreakpointsData newBreakpointsData) {
+    breakpoints = newBreakpointsData;
+    notifyListeners();
+  }
+
+  /// Updates the box shadows data and notifies listeners.
+  void updateBoxShadowsData(XBoxShadowsData newBoxShadowsData) {
+    boxShadows = newBoxShadowsData;
+    notifyListeners();
+  }
+
+  /// Updates the text shadows data and notifies listeners.
+  void updateTextShadowsData(XTextShadowsData newTextShadowsData) {
+    textShadows = newTextShadowsData;
+    notifyListeners();
+  }
+
+  /// Updates the form factor and notifies listeners.
+  void updateFormFactor(XFormFactor newFormFactor) {
+    formFactor = newFormFactor;
+    notifyListeners();
+  }
+
   void resetMetricsData() {
     _primaryColor = _m3Baseline;
     primaryColorTextFieldController.clear();

--- a/example/lib/widgets/metrics_editor.dart
+++ b/example/lib/widgets/metrics_editor.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:material_toolkit/material_toolkit.dart';
+import 'package:provider/provider.dart';
+
+import '../notifiers/theme_notifier.dart';
+
+/// Widget that exposes simple setters for [XMetricsData] fields.
+class MetricsEditor extends StatelessWidget {
+  const MetricsEditor({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    final metrics = theme.extension<XMetricsData>()!;
+    final gaps = metrics.gaps;
+
+    final themeNotifier = Provider.of<ThemeNotifier>(context);
+
+    return Card(
+      child: Padding(
+        padding: metrics.padding.all(XSpaces.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Metrics Editor', style: textTheme.titleLarge),
+            gaps.small,
+            _NumberField(
+              label: 'Spaces small',
+              initial: themeNotifier.spaces.small.toString(),
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateSpacesData(
+                    XSpacesData(
+                      superSmall: themeNotifier.spaces.superSmall,
+                      extraSmall: themeNotifier.spaces.extraSmall,
+                      small: v,
+                      semiSmall: themeNotifier.spaces.semiSmall,
+                      medium: themeNotifier.spaces.medium,
+                      semiLarge: themeNotifier.spaces.semiLarge,
+                      large: themeNotifier.spaces.large,
+                      extraLarge: themeNotifier.spaces.extraLarge,
+                      superLarge: themeNotifier.spaces.superLarge,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'Radii extraSmall',
+              initial: themeNotifier.radiiData.extraSmall.toString(),
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateRadiiData(
+                    themeNotifier.radiiData.copyWith(extraSmall: v),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'IconSize small',
+              initial: themeNotifier.iconSizes.small.toString(),
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateIconSizesData(
+                    XIconSizesData(
+                      extraSmall: themeNotifier.iconSizes.extraSmall,
+                      small: v,
+                      semiSmall: themeNotifier.iconSizes.semiSmall,
+                      medium: themeNotifier.iconSizes.medium,
+                      semiLarge: themeNotifier.iconSizes.semiLarge,
+                      large: themeNotifier.iconSizes.large,
+                      extraLarge: themeNotifier.iconSizes.extraLarge,
+                      superLarge: themeNotifier.iconSizes.superLarge,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'Elevation level1',
+              initial: themeNotifier.elevations.level1.toString(),
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateElevationsData(
+                    XElevationsData(
+                      level1: v,
+                      level2: themeNotifier.elevations.level2,
+                      level3: themeNotifier.elevations.level3,
+                      level4: themeNotifier.elevations.level4,
+                      level5: themeNotifier.elevations.level5,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'Duration slow (ms)',
+              initial: themeNotifier.durations.slow.inMilliseconds.toString(),
+              onChanged: (value) {
+                final v = int.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateDurationsData(
+                    XDurationsData(
+                      areAnimationEnabled:
+                          themeNotifier.durations.areAnimationEnabled,
+                      slow: Duration(milliseconds: v),
+                      regular: themeNotifier.durations.regular,
+                      quick: themeNotifier.durations.quick,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            DropdownButton<XFormFactor>(
+              value: themeNotifier.formFactor,
+              onChanged: (value) {
+                if (value != null) {
+                  themeNotifier.updateFormFactor(value);
+                }
+              },
+              items: XFormFactor.values
+                  .map(
+                    (e) => DropdownMenuItem(
+                      value: e,
+                      child: Text(e.toString().split('.').last),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NumberField extends StatelessWidget {
+  final String label;
+  final String initial;
+  final ValueChanged<String> onChanged;
+
+  const _NumberField({
+    required this.label,
+    required this.initial,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = TextEditingController(text: initial);
+    return TextField(
+      decoration: InputDecoration(labelText: label),
+      keyboardType: TextInputType.number,
+      onChanged: onChanged,
+      controller: controller,
+    );
+  }
+}
+

--- a/example/lib/widgets/metrics_editor.dart
+++ b/example/lib/widgets/metrics_editor.dart
@@ -27,14 +27,10 @@ class _MetricsEditorState extends State<MetricsEditor> {
   void initState() {
     super.initState();
     final notifier = context.read<ThemeNotifier>();
-    spacesSmallController =
-        TextEditingController(text: notifier.spaces.small.toString());
-    radiiExtraSmallController =
-        TextEditingController(text: notifier.radiiData.extraSmall.toString());
-    iconSmallController =
-        TextEditingController(text: notifier.iconSizes.small.toString());
-    elevationOneController =
-        TextEditingController(text: notifier.elevations.level1.toString());
+    spacesSmallController = TextEditingController(text: notifier.spaces.small.toString());
+    radiiExtraSmallController = TextEditingController(text: notifier.radiiData.extraSmall.toString());
+    iconSmallController = TextEditingController(text: notifier.iconSizes.small.toString());
+    elevationOneController = TextEditingController(text: notifier.elevations.level1.toString());
     durationSlowController = TextEditingController(
       text: notifier.durations.slow.inMilliseconds.toString(),
     );
@@ -71,7 +67,7 @@ class _MetricsEditorState extends State<MetricsEditor> {
 
     return Card(
       child: Padding(
-        padding: metrics.padding.all(XSpaces.medium),
+        padding: metrics.edgeInsets.all(XSpaces.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -162,8 +158,7 @@ class _MetricsEditorState extends State<MetricsEditor> {
                 if (v != null) {
                   themeNotifier.updateDurationsData(
                     XDurationsData(
-                      areAnimationEnabled:
-                          themeNotifier.durations.areAnimationEnabled,
+                      areAnimationEnabled: themeNotifier.durations.areAnimationEnabled,
                       slow: Duration(milliseconds: v),
                       regular: themeNotifier.durations.regular,
                       quick: themeNotifier.durations.quick,
@@ -221,7 +216,7 @@ class _MetricsEditorState extends State<MetricsEditor> {
                   final small = themeNotifier.textShadows.small;
                   themeNotifier.updateTextShadowsData(
                     XTextShadowsData(
-                      small: small.copyWith(blurRadius: v),
+                      small: small, // .copyWith(blurRadius: v), // TODO(Kevin): create copyWith feature
                       medium: themeNotifier.textShadows.medium,
                       large: themeNotifier.textShadows.large,
                     ),

--- a/example/lib/widgets/metrics_editor.dart
+++ b/example/lib/widgets/metrics_editor.dart
@@ -4,19 +4,70 @@ import 'package:provider/provider.dart';
 
 import '../notifiers/theme_notifier.dart';
 
-/// Widget that exposes simple setters for [XMetricsData] fields.
-class MetricsEditor extends StatelessWidget {
+/// Widget to edit [XMetricsData] values without losing the focus of the
+/// text fields while typing.
+class MetricsEditor extends StatefulWidget {
   const MetricsEditor({super.key});
+
+  @override
+  State<MetricsEditor> createState() => _MetricsEditorState();
+}
+
+class _MetricsEditorState extends State<MetricsEditor> {
+  late final TextEditingController spacesSmallController;
+  late final TextEditingController radiiExtraSmallController;
+  late final TextEditingController iconSmallController;
+  late final TextEditingController elevationOneController;
+  late final TextEditingController durationSlowController;
+  late final TextEditingController breakpointMobileMaxController;
+  late final TextEditingController boxShadowBlurController;
+  late final TextEditingController textShadowBlurController;
+
+  @override
+  void initState() {
+    super.initState();
+    final notifier = context.read<ThemeNotifier>();
+    spacesSmallController =
+        TextEditingController(text: notifier.spaces.small.toString());
+    radiiExtraSmallController =
+        TextEditingController(text: notifier.radiiData.extraSmall.toString());
+    iconSmallController =
+        TextEditingController(text: notifier.iconSizes.small.toString());
+    elevationOneController =
+        TextEditingController(text: notifier.elevations.level1.toString());
+    durationSlowController = TextEditingController(
+      text: notifier.durations.slow.inMilliseconds.toString(),
+    );
+    breakpointMobileMaxController = TextEditingController(
+      text: notifier.breakpoints.mobile.maxWidth.toString(),
+    );
+    boxShadowBlurController = TextEditingController(
+      text: notifier.boxShadows.small.blurRadius.toString(),
+    );
+    textShadowBlurController = TextEditingController(
+      text: notifier.textShadows.small.blurRadius.toString(),
+    );
+  }
+
+  @override
+  void dispose() {
+    spacesSmallController.dispose();
+    radiiExtraSmallController.dispose();
+    iconSmallController.dispose();
+    elevationOneController.dispose();
+    durationSlowController.dispose();
+    breakpointMobileMaxController.dispose();
+    boxShadowBlurController.dispose();
+    textShadowBlurController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-
     final metrics = theme.extension<XMetricsData>()!;
     final gaps = metrics.gaps;
-
-    final themeNotifier = Provider.of<ThemeNotifier>(context);
+    final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
 
     return Card(
       child: Padding(
@@ -24,11 +75,11 @@ class MetricsEditor extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text('Metrics Editor', style: textTheme.titleLarge),
+            Text('Metrics Editor', style: theme.textTheme.titleLarge),
             gaps.small,
             _NumberField(
               label: 'Spaces small',
-              initial: themeNotifier.spaces.small.toString(),
+              controller: spacesSmallController,
               onChanged: (value) {
                 final v = double.tryParse(value);
                 if (v != null) {
@@ -51,7 +102,7 @@ class MetricsEditor extends StatelessWidget {
             gaps.small,
             _NumberField(
               label: 'Radii extraSmall',
-              initial: themeNotifier.radiiData.extraSmall.toString(),
+              controller: radiiExtraSmallController,
               onChanged: (value) {
                 final v = double.tryParse(value);
                 if (v != null) {
@@ -64,7 +115,7 @@ class MetricsEditor extends StatelessWidget {
             gaps.small,
             _NumberField(
               label: 'IconSize small',
-              initial: themeNotifier.iconSizes.small.toString(),
+              controller: iconSmallController,
               onChanged: (value) {
                 final v = double.tryParse(value);
                 if (v != null) {
@@ -86,7 +137,7 @@ class MetricsEditor extends StatelessWidget {
             gaps.small,
             _NumberField(
               label: 'Elevation level1',
-              initial: themeNotifier.elevations.level1.toString(),
+              controller: elevationOneController,
               onChanged: (value) {
                 final v = double.tryParse(value);
                 if (v != null) {
@@ -105,7 +156,7 @@ class MetricsEditor extends StatelessWidget {
             gaps.small,
             _NumberField(
               label: 'Duration slow (ms)',
-              initial: themeNotifier.durations.slow.inMilliseconds.toString(),
+              controller: durationSlowController,
               onChanged: (value) {
                 final v = int.tryParse(value);
                 if (v != null) {
@@ -116,6 +167,63 @@ class MetricsEditor extends StatelessWidget {
                       slow: Duration(milliseconds: v),
                       regular: themeNotifier.durations.regular,
                       quick: themeNotifier.durations.quick,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'Breakpoint mobile max',
+              controller: breakpointMobileMaxController,
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  themeNotifier.updateBreakpointsData(
+                    XBreakpointsData(
+                      mobile: XBreakpoint(
+                        minWidth: themeNotifier.breakpoints.mobile.minWidth,
+                        maxWidth: v,
+                      ),
+                      tablet: themeNotifier.breakpoints.tablet,
+                      desktop: themeNotifier.breakpoints.desktop,
+                      infinity: themeNotifier.breakpoints.infinity,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'BoxShadow small blur',
+              controller: boxShadowBlurController,
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  final small = themeNotifier.boxShadows.small;
+                  themeNotifier.updateBoxShadowsData(
+                    XBoxShadowsData(
+                      small: small.copyWith(blurRadius: v),
+                      medium: themeNotifier.boxShadows.medium,
+                      large: themeNotifier.boxShadows.large,
+                    ),
+                  );
+                }
+              },
+            ),
+            gaps.small,
+            _NumberField(
+              label: 'TextShadow small blur',
+              controller: textShadowBlurController,
+              onChanged: (value) {
+                final v = double.tryParse(value);
+                if (v != null) {
+                  final small = themeNotifier.textShadows.small;
+                  themeNotifier.updateTextShadowsData(
+                    XTextShadowsData(
+                      small: small.copyWith(blurRadius: v),
+                      medium: themeNotifier.textShadows.medium,
+                      large: themeNotifier.textShadows.large,
                     ),
                   );
                 }
@@ -147,24 +255,22 @@ class MetricsEditor extends StatelessWidget {
 
 class _NumberField extends StatelessWidget {
   final String label;
-  final String initial;
+  final TextEditingController controller;
   final ValueChanged<String> onChanged;
 
   const _NumberField({
     required this.label,
-    required this.initial,
+    required this.controller,
     required this.onChanged,
   });
 
   @override
   Widget build(BuildContext context) {
-    final controller = TextEditingController(text: initial);
     return TextField(
       decoration: InputDecoration(labelText: label),
       keyboardType: TextInputType.number,
-      onChanged: onChanged,
       controller: controller,
+      onChanged: onChanged,
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- allow editing all fields in ThemeNotifier
- add `MetricsEditor` widget to modify metrics
- show `MetricsEditor` on the example screen

## Testing
- `dart format -o none .` *(fails: command not found)*
- `flutter format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686553bf188c832294350a762f7ea551