### PR TITLE
Rename metrics classes to design tokens

### DIFF
--- a/example/lib/geometry/elevation.dart
+++ b/example/lib/geometry/elevation.dart
@@ -11,7 +11,7 @@ class ElevationGroup extends StatelessWidget {
     // final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     // final borderRadius = metrics.borderRadius;
     // final edgeInsets = metrics.edgeInsets;
     final elevations = metrics.elevations;

--- a/example/lib/geometry/radius.dart
+++ b/example/lib/geometry/radius.dart
@@ -12,7 +12,7 @@
 //   Widget build(BuildContext context) {
 //     final theme = Theme.of(context);
 
-//     final metrics = theme.extension<XMetricsData>()!;
+//     final metrics = theme.extension<DesignTokensData>()!;
 //     final gaps = metrics.gaps;
 //     final radii = metrics.radii;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,7 @@ class _RootState extends State<Root> {
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final gaps = metrics.gaps;
     // final inputBorders = metrics.inputBorders;
     // final breakpoints = metrics.breakpoints;

--- a/example/lib/notifiers/theme_notifier.dart
+++ b/example/lib/notifiers/theme_notifier.dart
@@ -31,7 +31,7 @@ class ThemeNotifier extends ChangeNotifier {
   /// Gets the current radii data used in the theme.
   XRadiiData get radiiData => _radiiData;
 
-  XMetricsData get metrics => XMetricsData(
+  DesignTokensData get metrics => DesignTokensData(
         boxShadows: boxShadows,
         breakpoints: breakpoints,
         durations: durations,

--- a/example/lib/paiting/border_radius_all.dart
+++ b/example/lib/paiting/border_radius_all.dart
@@ -13,7 +13,7 @@ class BorderRadiusAllGroup extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final borderRadius = metrics.borderRadius;
     // final border = metrics.borderRadius;
 
@@ -116,7 +116,7 @@ class BorderRadiusCircularComponent extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final borderRadius = metrics.borderRadius;
 
     return BorderRadiusComponent(
@@ -145,7 +145,7 @@ class BorderRadiusComponent extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     // final border = metrics.borderRadius;
 
     final gaps = metrics.gaps;

--- a/example/lib/paiting/border_radius_circular_group.dart
+++ b/example/lib/paiting/border_radius_circular_group.dart
@@ -13,7 +13,7 @@ class BorderRadiusCircularGroup extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     // final borderRadius = metrics.borderRadius;
 
     final gaps = metrics.gaps;
@@ -74,7 +74,7 @@ class BorderRadiusCircularComponent extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final borderRadius = metrics.borderRadius;
 
     return BorderRadiusComponent(
@@ -103,7 +103,7 @@ class BorderRadiusComponent extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     // final borderRadius = metrics.borderRadius;
 
     final gaps = metrics.gaps;

--- a/example/lib/paiting/border_shapes.dart
+++ b/example/lib/paiting/border_shapes.dart
@@ -12,7 +12,7 @@ class BorderRadiusGroup extends StatelessWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final borderRadius = metrics.borderRadius;
     final gaps = metrics.gaps;
 

--- a/example/lib/styles/metrics.dart
+++ b/example/lib/styles/metrics.dart
@@ -9,7 +9,7 @@
 //   double get level7 => 16;
 // }
 
-// XMetricsData metrics({required XRadiiData radii}) => XMetricsData(
+// DesignTokensData metrics({required XRadiiData radii}) => DesignTokensData(
 //       elevations: const CustomElevationsData(),
 //       radii: radii,
 //     );

--- a/example/lib/widgets/group_card.dart
+++ b/example/lib/widgets/group_card.dart
@@ -17,7 +17,7 @@ class GroupCard extends StatelessWidget {
     final textTheme = theme.textTheme;
     final colorScheme = theme.colorScheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final padding = metrics.padding;
     final gaps = metrics.gaps;
 

--- a/example/lib/widgets/group_item_container.dart
+++ b/example/lib/widgets/group_item_container.dart
@@ -14,7 +14,7 @@ class GroupItemContainer extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final borderRadius = metrics.borderRadius;
     final edgeInsets = metrics.edgeInsets;
 

--- a/example/lib/widgets/group_item_subtitle.dart
+++ b/example/lib/widgets/group_item_subtitle.dart
@@ -15,7 +15,7 @@ class GroupItemSubtitle extends StatelessWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final gaps = metrics.gaps;
 
     return Row(

--- a/example/lib/widgets/group_item_title.dart
+++ b/example/lib/widgets/group_item_title.dart
@@ -14,7 +14,7 @@ class GroupItemTitle extends StatelessWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    final metrics = theme.extension<XMetricsData>()!;
+    final metrics = theme.extension<DesignTokensData>()!;
     final gaps = metrics.gaps;
 
     return Row(

--- a/lib/material_toolkit.dart
+++ b/lib/material_toolkit.dart
@@ -3,4 +3,4 @@ library material_toolkit;
 // export 'src/base/assets/x_assets_data.dart';
 // TODO(all): NOW - CHANGE IT ALL TO BE PART OF THE LIB
 export 'src/base/helpers/x_helpers.dart';
-export 'src/base/metrics/x_metrics_data.dart';
+export 'src/base/metrics/design_tokens.dart';

--- a/lib/src/base/metrics/animation/x_durations_data.dart
+++ b/lib/src/base/metrics/animation/x_durations_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XDurationsData extends Equatable {
   // final bool? _areAnimationEnabled;

--- a/lib/src/base/metrics/design_tokens.dart
+++ b/lib/src/base/metrics/design_tokens.dart
@@ -1,4 +1,4 @@
-library x_metrics_data;
+library design_tokens;
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
@@ -30,28 +30,28 @@ part 'painting/x_gaps.dart';
 part 'painting/x_padding.dart';
 part 'painting/x_text_shadows_data.dart';
 
-class XMetrics extends InheritedWidget {
-  const XMetrics({required super.child, required this.data, super.key});
+class DesignTokens extends InheritedWidget {
+  const DesignTokens({required super.child, required this.data, super.key});
 
-  static XMetricsData of(BuildContext context) {
-    final metricsData = context.dependOnInheritedWidgetOfExactType<XMetrics>()?.data;
+  static DesignTokensData of(BuildContext context) {
+    final metricsData = context.dependOnInheritedWidgetOfExactType<DesignTokens>()?.data;
 
-    assert(metricsData != null, 'No XMetrics found in context');
+    assert(metricsData != null, 'No DesignTokens found in context');
 
     return metricsData!;
   }
 
-  static XMetricsData? maybeOf(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<XMetrics>()?.data;
+  static DesignTokensData? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DesignTokens>()?.data;
   }
 
-  final XMetricsData data;
+  final DesignTokensData data;
 
   @override
-  bool updateShouldNotify(XMetrics oldWidget) => data != oldWidget.data;
+  bool updateShouldNotify(DesignTokens oldWidget) => data != oldWidget.data;
 }
 
-class XMetricsData extends ThemeExtension<XMetricsData> {
+class DesignTokensData extends ThemeExtension<DesignTokensData> {
   final XBoxShadowsData boxShadows;
   final XBreakpointsData breakpoints;
   final XDurationsData durations;
@@ -64,7 +64,7 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
   final XTextShadowsData textShadows;
   // blurs
 
-  XMetricsData({
+  DesignTokensData({
     final XBoxShadowsData? boxShadows,
     final XBreakpointsData? breakpoints,
     final XDurationsData? durations,
@@ -100,11 +100,11 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
   // GoogleFonts get googleFonts => GoogleFonts;
 
   @override
-  ThemeExtension<XMetricsData> lerp(ThemeExtension<XMetricsData>? other, double t) {
-    if (other is! XMetricsData) {
+  ThemeExtension<DesignTokensData> lerp(ThemeExtension<DesignTokensData>? other, double t) {
+    if (other is! DesignTokensData) {
       return this;
     } else {
-      return XMetricsData(
+      return DesignTokensData(
         boxShadows: boxShadows,
         breakpoints: breakpoints,
         durations: durations,
@@ -120,7 +120,7 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
   }
 
   @override
-  XMetricsData copyWith({
+  DesignTokensData copyWith({
     XBoxShadowsData? boxShadows,
     XBreakpointsData? breakpoints,
     XDurationsData? durations,
@@ -132,7 +132,7 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
     XSpacesData? spaces,
     XTextShadowsData? textShadows,
   }) {
-    return XMetricsData(
+    return DesignTokensData(
       boxShadows: boxShadows ?? this.boxShadows,
       breakpoints: breakpoints ?? this.breakpoints,
       durations: durations ?? this.durations,
@@ -149,7 +149,7 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is XMetricsData &&
+      other is DesignTokensData &&
           boxShadows == other.boxShadows &&
           breakpoints == other.breakpoints &&
           durations == other.durations &&
@@ -174,7 +174,7 @@ class XMetricsData extends ThemeExtension<XMetricsData> {
 
   @override
   String toString() => '''
-    XMetricsData(
+    DesignTokensData(
       boxShadows: $boxShadows,
       breakpoints: $breakpoints,
       durations: $durations,

--- a/lib/src/base/metrics/geometry/x_breakpoints_data.dart
+++ b/lib/src/base/metrics/geometry/x_breakpoints_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XBreakpointsData extends Equatable {
   // final Breakpoint? _mobile;

--- a/lib/src/base/metrics/geometry/x_elevations_data.dart
+++ b/lib/src/base/metrics/geometry/x_elevations_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XElevationsData extends Equatable {
   // final double? _level1;

--- a/lib/src/base/metrics/geometry/x_form_factor.dart
+++ b/lib/src/base/metrics/geometry/x_form_factor.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 enum XFormFactor {
   small,

--- a/lib/src/base/metrics/geometry/x_icon_sizes_data.dart
+++ b/lib/src/base/metrics/geometry/x_icon_sizes_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XIconSizesData extends Equatable {
   final double _extraSmall;

--- a/lib/src/base/metrics/geometry/x_radii_data.dart
+++ b/lib/src/base/metrics/geometry/x_radii_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 enum XRadii {
   none,

--- a/lib/src/base/metrics/geometry/x_radius copy 2.dart
+++ b/lib/src/base/metrics/geometry/x_radius copy 2.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // class XRadius extends Radius {
 //   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/geometry/x_radius copy 3.dart
+++ b/lib/src/base/metrics/geometry/x_radius copy 3.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // class XRadius {
 //   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/geometry/x_radius copy 4.dart
+++ b/lib/src/base/metrics/geometry/x_radius copy 4.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // /// A radius for either circular or elliptical shapes.
 // class XRadius {

--- a/lib/src/base/metrics/geometry/x_radius copy.dart
+++ b/lib/src/base/metrics/geometry/x_radius copy.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // class XRadius extends Equatable {
 //   final XRadiiData _radii;

--- a/lib/src/base/metrics/geometry/x_radius.dart
+++ b/lib/src/base/metrics/geometry/x_radius.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 extension XRadiusExtension on XRadius {
   /// Converts [XRadius] to a Flutter [Radius].

--- a/lib/src/base/metrics/geometry/x_spaces_data.dart
+++ b/lib/src/base/metrics/geometry/x_spaces_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 enum XSpaces {
   none,

--- a/lib/src/base/metrics/painting/borders/input/x_input_borders.dart
+++ b/lib/src/base/metrics/painting/borders/input/x_input_borders.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 class XInputBorders extends Equatable {
   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/painting/borders/input/x_outline_input_border.dart
+++ b/lib/src/base/metrics/painting/borders/input/x_outline_input_border.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 /// Extensão para a classe [XOutlineInputBorder] que adiciona um método
 /// para converter em um [OutlineInputBorder] do Flutter.

--- a/lib/src/base/metrics/painting/borders/input/x_underline_input_border.dart
+++ b/lib/src/base/metrics/painting/borders/input/x_underline_input_border.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 /// Extensão para a classe [XUnderlineInputBorder] que adiciona um método
 /// para converter em um [UnderlineInputBorder] do Flutter.

--- a/lib/src/base/metrics/painting/borders/shape/x_beveled_rectangle_border.dart
+++ b/lib/src/base/metrics/painting/borders/shape/x_beveled_rectangle_border.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 /// Extensão para a classe [XBeveledRectangleBorder] que adiciona um método
 /// para converter em um [BeveledRectangleBorder] do Flutter.

--- a/lib/src/base/metrics/painting/borders/shape/x_continuous_rectangle_border.dart
+++ b/lib/src/base/metrics/painting/borders/shape/x_continuous_rectangle_border.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 /// Extensão para a classe [XContinuousRectangleBorder] que adiciona um método
 /// para converter em um [ContinuousRectangleBorder] do Flutter.

--- a/lib/src/base/metrics/painting/borders/shape/x_rounded_rectangle_border.dart
+++ b/lib/src/base/metrics/painting/borders/shape/x_rounded_rectangle_border.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 /// Extensão para a classe [XRoundedRectangleBorder] que adiciona um método
 /// para converter em um [RoundedRectangleBorder] do Flutter.

--- a/lib/src/base/metrics/painting/borders/shape/x_shapes.dart
+++ b/lib/src/base/metrics/painting/borders/shape/x_shapes.dart
@@ -1,4 +1,4 @@
-part of '../../../x_metrics_data.dart';
+part of '../../../design_tokens.dart';
 
 class XShapes extends Equatable {
   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/painting/borders/x_border_radii.dart
+++ b/lib/src/base/metrics/painting/borders/x_border_radii.dart
@@ -1,4 +1,4 @@
-part of '../../x_metrics_data.dart';
+part of '../../design_tokens.dart';
 
 class XBorderRadii extends Equatable {
   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/painting/borders/x_border_radius.dart
+++ b/lib/src/base/metrics/painting/borders/x_border_radius.dart
@@ -1,4 +1,4 @@
-part of '../../x_metrics_data.dart';
+part of '../../design_tokens.dart';
 
 extension XBorderRadiusExtension on XBorderRadius {
   /// Converts [XBorderRadius] to a Flutter [BorderRadius].

--- a/lib/src/base/metrics/painting/borders/x_border_shapes copy.dart
+++ b/lib/src/base/metrics/painting/borders/x_border_shapes copy.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // /// A utility class that provides various shape styles and borders, based on
 // /// the [_borderRadii] provided by [XBorderRadii].

--- a/lib/src/base/metrics/painting/borders/x_radius_controller.dart
+++ b/lib/src/base/metrics/painting/borders/x_radius_controller.dart
@@ -1,4 +1,4 @@
-part of '../../x_metrics_data.dart';
+part of '../../design_tokens.dart';
 
 class XRadiusController extends Equatable {
   final XRadiiData _radiiData;

--- a/lib/src/base/metrics/painting/x_box_shadows_data.dart
+++ b/lib/src/base/metrics/painting/x_box_shadows_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XBoxShadowsData extends Equatable {
   // final BoxShadow? _small;

--- a/lib/src/base/metrics/painting/x_edge_insets.dart
+++ b/lib/src/base/metrics/painting/x_edge_insets.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XEdgeInsets extends Equatable {
   final XSpacesData _spaces;

--- a/lib/src/base/metrics/painting/x_gaps.dart
+++ b/lib/src/base/metrics/painting/x_gaps.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XGaps extends Equatable {
   final XSpacesData _spaces;

--- a/lib/src/base/metrics/painting/x_google_fonts_data.dart
+++ b/lib/src/base/metrics/painting/x_google_fonts_data.dart
@@ -1,4 +1,4 @@
-// part of '../x_metrics_data.dart';
+// part of '../design_tokens.dart';
 
 // class XGoogleFontsData extends Equatable {
 //   const XGoogleFontsData();

--- a/lib/src/base/metrics/painting/x_padding.dart
+++ b/lib/src/base/metrics/painting/x_padding.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XPadding extends Equatable {
   final XEdgeInsets _edgeInsets;

--- a/lib/src/base/metrics/painting/x_text_shadows_data.dart
+++ b/lib/src/base/metrics/painting/x_text_shadows_data.dart
@@ -1,4 +1,4 @@
-part of '../x_metrics_data.dart';
+part of '../design_tokens.dart';
 
 class XTextShadowsData extends Equatable {
   // final Shadow? _small;

--- a/test/design_tokens_test.dart
+++ b/test/design_tokens_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_toolkit/material_toolkit.dart';
+
+void main() {
+  testWidgets('DesignTokens.of returns provided data', (tester) async {
+    final data = DesignTokensData();
+    await tester.pumpWidget(
+      DesignTokens(
+        data: data,
+        child: MaterialApp(
+          theme: ThemeData(
+            extensions: [data],
+          ),
+          home: const SizedBox(),
+        ),
+      ),
+    );
+
+    final context = tester.element(find.byType(SizedBox));
+    expect(DesignTokens.of(context), equals(data));
+    expect(Theme.of(context).extension<DesignTokensData>(), equals(data));
+  });
+}


### PR DESCRIPTION
## Summary
- rename XMetrics classes to DesignTokens
- update export to design_tokens.dart
- adjust part directives to use new file name
- replace references in the example app
- add a widget test for DesignTokens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711d692a3c8322bd0281cf3a5046f6