### PR TITLE
Add preset factory with override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ Add `material_toolkit` to your `pubspec.yaml` file:
 ```yaml
 dependencies:
   material_toolkit: ^0.0.4
+```
+
+### Material presets
+
+Use `DesignTokensData.material()` to obtain Material defaults. Override any
+value with a map or JSON string:
+
+```dart
+final tokens = XDesignTokensData.material(overrides: {
+  "spaces": {"medium": 20.0},
+});
+```
+
+JSON can be loaded with `XDesignTokensData.fromJson` for the same effect.
+

--- a/lib/src/base/tokens/animation/x_durations_data.dart
+++ b/lib/src/base/tokens/animation/x_durations_data.dart
@@ -31,6 +31,21 @@ class XDurationsData extends Equatable {
         _regular = regular ?? const Duration(milliseconds: XStandardMilliseconds.x300),
         _quick = quick ?? const Duration(milliseconds: XStandardMilliseconds.x100);
 
+  factory XDurationsData.fromMap(Map<String, dynamic> map) {
+    Duration? _d(String key) {
+      final value = map[key];
+      if (value is int) return Duration(milliseconds: value);
+      return null;
+    }
+
+    return XDurationsData(
+      areAnimationEnabled: map['areAnimationEnabled'] as bool?,
+      slow: _d('slow'),
+      regular: _d('regular'),
+      quick: _d('quick'),
+    );
+  }
+
   // XDurationsData.x({
   //   final XAttribute<bool?>? areAnimationEnabled,
   //   final XAttribute<Duration?>? slow,

--- a/lib/src/base/tokens/geometry/x_breakpoints_data.dart
+++ b/lib/src/base/tokens/geometry/x_breakpoints_data.dart
@@ -47,6 +47,26 @@ class XBreakpointsData extends Equatable {
               maxWidth: double.infinity,
             );
 
+  factory XBreakpointsData.fromMap(Map<String, dynamic> map) {
+    XBreakpoint? _b(String key) {
+      final value = map[key];
+      if (value is Map<String, dynamic>) {
+        return XBreakpoint(
+          minWidth: (value['minWidth'] as num?)?.toDouble() ?? 0,
+          maxWidth: (value['maxWidth'] as num?)?.toDouble() ?? double.infinity,
+        );
+      }
+      return null;
+    }
+
+    return XBreakpointsData(
+      mobile: _b('mobile'),
+      tablet: _b('tablet'),
+      desktop: _b('desktop'),
+      infinity: _b('infinity'),
+    );
+  }
+
   // XBreakpointsData.x({
   //   final XAttribute<Breakpoint?>? mobile,
   //   final XAttribute<Breakpoint?>? tablet,

--- a/lib/src/base/tokens/geometry/x_elevations_data.dart
+++ b/lib/src/base/tokens/geometry/x_elevations_data.dart
@@ -37,6 +37,18 @@ class XElevationsData extends Equatable {
         _level4 = level4 ?? XStandardSizes.x8,
         _level5 = level5 ?? XStandardSizes.x12;
 
+  factory XElevationsData.fromMap(Map<String, dynamic> map) {
+    double? _d(String key) => (map[key] as num?)?.toDouble();
+
+    return XElevationsData(
+      level1: _d('level1'),
+      level2: _d('level2'),
+      level3: _d('level3'),
+      level4: _d('level4'),
+      level5: _d('level5'),
+    );
+  }
+
   // XElevationsData.x({
   //   final XAttribute<double?>? level1,
   //   final XAttribute<double?>? level2,

--- a/lib/src/base/tokens/geometry/x_icon_sizes_data.dart
+++ b/lib/src/base/tokens/geometry/x_icon_sizes_data.dart
@@ -28,6 +28,21 @@ class XIconSizesData extends Equatable {
         _extraLarge = extraLarge ?? XStandardSizes.x96,
         _superLarge = superLarge ?? XStandardSizes.x192;
 
+  factory XIconSizesData.fromMap(Map<String, dynamic> map) {
+    double? _d(String key) => (map[key] as num?)?.toDouble();
+
+    return XIconSizesData(
+      extraSmall: _d('extraSmall'),
+      small: _d('small'),
+      semiSmall: _d('semiSmall'),
+      medium: _d('medium'),
+      semiLarge: _d('semiLarge'),
+      large: _d('large'),
+      extraLarge: _d('extraLarge'),
+      superLarge: _d('superLarge'),
+    );
+  }
+
   double get none => XStandardSizes.zero;
   double get extraSmall => _extraSmall;
   double get small => _small;

--- a/lib/src/base/tokens/geometry/x_radii_data.dart
+++ b/lib/src/base/tokens/geometry/x_radii_data.dart
@@ -83,6 +83,21 @@ class XRadiiData extends Equatable {
         _extraLarge = extraLarge ?? XStandardSizes.x32,
         _superLarge = superLarge ?? XStandardSizes.x48;
 
+  factory XRadiiData.fromMap(Map<String, dynamic> map) {
+    double? _d(String key) => (map[key] as num?)?.toDouble();
+
+    return XRadiiData(
+      extraSmall: _d('extraSmall'),
+      small: _d('small'),
+      semiSmall: _d('semiSmall'),
+      medium: _d('medium'),
+      semiLarge: _d('semiLarge'),
+      large: _d('large'),
+      extraLarge: _d('extraLarge'),
+      superLarge: _d('superLarge'),
+    );
+  }
+
   // XRadiiData.x({
   //   final XAttribute<double?>? extraSmall,
   //   final XAttribute<double?>? small,

--- a/lib/src/base/tokens/geometry/x_spaces_data.dart
+++ b/lib/src/base/tokens/geometry/x_spaces_data.dart
@@ -91,6 +91,22 @@ class XSpacesData extends Equatable {
         _extraLarge = extraLarge ?? XStandardSizes.x32,
         _superLarge = superLarge ?? XStandardSizes.x48;
 
+  factory XSpacesData.fromMap(Map<String, dynamic> map) {
+    double? _d(String key) => (map[key] as num?)?.toDouble();
+
+    return XSpacesData(
+      superSmall: _d('superSmall'),
+      extraSmall: _d('extraSmall'),
+      small: _d('small'),
+      semiSmall: _d('semiSmall'),
+      medium: _d('medium'),
+      semiLarge: _d('semiLarge'),
+      large: _d('large'),
+      extraLarge: _d('extraLarge'),
+      superLarge: _d('superLarge'),
+    );
+  }
+
   // XSpacesData.x({
   //   final XAttribute<double?>? superSmall,
   //   final XAttribute<double?>? extraSmall,

--- a/lib/src/base/tokens/painting/x_box_shadows_data.dart
+++ b/lib/src/base/tokens/painting/x_box_shadows_data.dart
@@ -40,6 +40,30 @@ class XBoxShadowsData extends Equatable {
               color: Color(0x44000000),
             );
 
+  factory XBoxShadowsData.fromMap(Map<String, dynamic> map) {
+    BoxShadow? _bs(String key) {
+      final value = map[key];
+      if (value is Map<String, dynamic>) {
+        return BoxShadow(
+          blurRadius: (value['blurRadius'] as num?)?.toDouble() ?? 0,
+          spreadRadius: (value['spreadRadius'] as num?)?.toDouble() ?? 0,
+          offset: Offset(
+            (value['offsetX'] as num?)?.toDouble() ?? 0,
+            (value['offsetY'] as num?)?.toDouble() ?? 0,
+          ),
+          color: Color((value['color'] as int?) ?? 0x44000000),
+        );
+      }
+      return null;
+    }
+
+    return XBoxShadowsData(
+      small: _bs('small'),
+      medium: _bs('medium'),
+      large: _bs('large'),
+    );
+  }
+
   // XBoxShadowsData.x({
   //   final XAttribute<BoxShadow?>? small,
   //   final XAttribute<BoxShadow?>? medium,

--- a/lib/src/base/tokens/painting/x_text_shadows_data.dart
+++ b/lib/src/base/tokens/painting/x_text_shadows_data.dart
@@ -37,6 +37,29 @@ class XTextShadowsData extends Equatable {
               color: Color(0x44000000),
             );
 
+  factory XTextShadowsData.fromMap(Map<String, dynamic> map) {
+    Shadow? _s(String key) {
+      final value = map[key];
+      if (value is Map<String, dynamic>) {
+        return Shadow(
+          blurRadius: (value['blurRadius'] as num?)?.toDouble() ?? 0,
+          offset: Offset(
+            (value['offsetX'] as num?)?.toDouble() ?? 0,
+            (value['offsetY'] as num?)?.toDouble() ?? 0,
+          ),
+          color: Color((value['color'] as int?) ?? 0x44000000),
+        );
+      }
+      return null;
+    }
+
+    return XTextShadowsData(
+      small: _s('small'),
+      medium: _s('medium'),
+      large: _s('large'),
+    );
+  }
+
   // XTextShadowsData.x({
   //   final XAttribute<Shadow?>? small,
   //   final XAttribute<Shadow?>? medium,

--- a/lib/src/base/tokens/x_design_tokens.dart
+++ b/lib/src/base/tokens/x_design_tokens.dart
@@ -4,6 +4,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:material_toolkit/material_toolkit.dart';
+import 'dart:convert';
 
 part 'animation/x_durations_data.dart';
 part 'geometry/x_breakpoints_data.dart';
@@ -85,6 +86,53 @@ class XDesignTokensData extends ThemeExtension<XDesignTokensData> {
         radii = radii ?? const XRadiiData(),
         spaces = spaces ?? const XSpacesData(),
         textShadows = textShadows ?? const XTextShadowsData();
+
+  factory XDesignTokensData.material({Map<String, dynamic>? overrides}) {
+    var data = XDesignTokensData();
+    if (overrides != null) {
+      data = data.copyWith(
+        boxShadows: overrides['boxShadows'] != null
+            ? XBoxShadowsData.fromMap(
+                overrides['boxShadows'] as Map<String, dynamic>)
+            : null,
+        breakpoints: overrides['breakpoints'] != null
+            ? XBreakpointsData.fromMap(
+                overrides['breakpoints'] as Map<String, dynamic>)
+            : null,
+        durations: overrides['durations'] != null
+            ? XDurationsData.fromMap(
+                overrides['durations'] as Map<String, dynamic>)
+            : null,
+        elevations: overrides['elevations'] != null
+            ? XElevationsData.fromMap(
+                overrides['elevations'] as Map<String, dynamic>)
+            : null,
+        iconSizes: overrides['iconSizes'] != null
+            ? XIconSizesData.fromMap(
+                overrides['iconSizes'] as Map<String, dynamic>)
+            : null,
+        radii: overrides['radii'] != null
+            ? XRadiiData.fromMap(overrides['radii'] as Map<String, dynamic>)
+            : null,
+        spaces: overrides['spaces'] != null
+            ? XSpacesData.fromMap(overrides['spaces'] as Map<String, dynamic>)
+            : null,
+        textShadows: overrides['textShadows'] != null
+            ? XTextShadowsData.fromMap(
+                overrides['textShadows'] as Map<String, dynamic>)
+            : null,
+      );
+    }
+    return data;
+  }
+
+  factory XDesignTokensData.fromMap(Map<String, dynamic> map) {
+    return XDesignTokensData.material(overrides: map);
+  }
+
+  factory XDesignTokensData.fromJson(String json) {
+    return XDesignTokensData.fromMap(jsonDecode(json) as Map<String, dynamic>);
+  }
 
   /// Spaces
   late final XGaps gaps = XGaps(spaces);


### PR DESCRIPTION
## Summary
- implement `XDesignTokensData.material` with map or JSON overrides
- add `.fromMap` constructors for token data classes
- expose `fromJson` helper
- document Material preset usage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712de12f048322b0173ab0c670890f