### PR TITLE
Add documentation to utility classes

### DIFF
--- a/lib/material_toolkit.dart
+++ b/lib/material_toolkit.dart
@@ -1,2 +1,6 @@
+/// Main export file for the Material Toolkit package.
+///
+/// This file exposes the helper utilities and design tokens used to build
+/// custom design systems on top of Flutter's `MaterialApp`.
 export 'src/base/helpers/x_helpers.dart';
 export 'src/base/tokens/x_design_tokens.dart';

--- a/lib/src/base/helpers/x_adaptive_widget.dart
+++ b/lib/src/base/helpers/x_adaptive_widget.dart
@@ -1,5 +1,11 @@
 part of 'x_helpers.dart';
 
+/// A [StatelessWidget] that builds platform specific widgets.
+///
+/// Override the platform build methods to provide custom widgets for each
+/// target platform. When a platform override is not provided the
+/// [standardBuild] implementation is used instead.
+
 abstract class XAdaptiveWidget extends StatelessWidget {
   const XAdaptiveWidget({super.key});
 

--- a/lib/src/base/helpers/x_auxiliary_milliseconds.dart
+++ b/lib/src/base/helpers/x_auxiliary_milliseconds.dart
@@ -1,5 +1,7 @@
 part of 'x_helpers.dart';
 
+/// Miscellaneous millisecond constants used by the design tokens.
+
 abstract final class XAuxiliaryMilliseconds {
   /// Random
   static const int x250 = 250;

--- a/lib/src/base/helpers/x_auxiliary_sizes.dart
+++ b/lib/src/base/helpers/x_auxiliary_sizes.dart
@@ -1,5 +1,7 @@
 part of 'x_helpers.dart';
 
+/// Additional size constants that complement [XStandardSizes].
+
 abstract final class XAuxiliarySizes {
   /// Random
   static const double x008 = 0.08;

--- a/lib/src/base/helpers/x_design_tokens_attribute_errors.dart
+++ b/lib/src/base/helpers/x_design_tokens_attribute_errors.dart
@@ -1,5 +1,7 @@
 part of 'x_helpers.dart';
 
+/// Error messages used when accessing unsupported design token attributes.
+
 enum XDesignTokensAttributeErrors {
   unsupportedError;
 

--- a/lib/src/base/helpers/x_helpers.dart
+++ b/lib/src/base/helpers/x_helpers.dart
@@ -1,3 +1,7 @@
+/// Collection of helper utilities shared across the Material Toolkit package.
+///
+/// This library exports platform adaptive widgets, common size constants and
+/// other small utilities that are reused by the design tokens.
 library;
 
 import 'package:equatable/equatable.dart';

--- a/lib/src/base/helpers/x_named_value.dart
+++ b/lib/src/base/helpers/x_named_value.dart
@@ -1,6 +1,6 @@
 part of 'x_helpers.dart';
 
-/// This class associated a [name] to a given [value].
+/// Associates a [name] to a given [value].
 class XNamedValue<T> extends Equatable {
   const XNamedValue(this.name, this.value);
 

--- a/lib/src/base/helpers/x_standard_milliseconds.dart
+++ b/lib/src/base/helpers/x_standard_milliseconds.dart
@@ -1,5 +1,7 @@
 part of 'x_helpers.dart';
 
+/// Standard durations used across the Material Toolkit animations.
+
 abstract final class XStandardMilliseconds {
   static const int zero = 0;
   static const int x100 = 100;

--- a/lib/src/base/helpers/x_standard_sizes.dart
+++ b/lib/src/base/helpers/x_standard_sizes.dart
@@ -1,5 +1,10 @@
 part of 'x_helpers.dart';
 
+/// Commonly used size constants.
+///
+/// These values follow a 4px grid and are meant to provide a
+/// predictable scale throughout the design system.
+
 abstract final class XStandardSizes {
   /// + 4
   static const double zero = 0;

--- a/lib/src/base/tokens/animation/x_durations_tokens.dart
+++ b/lib/src/base/tokens/animation/x_durations_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Duration values used for animations.
+
+/// Defines a set of durations for animations used throughout the UI.
 class XDurationsTokens extends Equatable {
   const XDurationsTokens({
     final bool? areAnimationEnabled,

--- a/lib/src/base/tokens/geometry/x_border_widths_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_border_widths_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Stroke widths used when drawing borders.
+
+/// Collection of standard border stroke widths.
 class XBorderWidthsTokens extends Equatable {
   const XBorderWidthsTokens({
     double? hairline,

--- a/lib/src/base/tokens/geometry/x_breakpoints_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_breakpoints_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Breakpoints defining responsive layout ranges.
+
+/// Contains screen size ranges for responsive layouts.
 class XBreakpointsTokens extends Equatable {
   const XBreakpointsTokens({
     XBreakpoint? mobile,

--- a/lib/src/base/tokens/geometry/x_elevations_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_elevations_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Elevation values used for Material surfaces.
+
+/// Collection of elevation constants for visual hierarchy.
 class XElevationsTokens extends Equatable {
   const XElevationsTokens({
     double? level1,

--- a/lib/src/base/tokens/geometry/x_form_factor.dart
+++ b/lib/src/base/tokens/geometry/x_form_factor.dart
@@ -1,5 +1,7 @@
 part of '../x_design_tokens.dart';
 
+/// Identifiers for device form factors.
+
 enum XFormFactor {
   small,
   medium,

--- a/lib/src/base/tokens/geometry/x_icon_sizes_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_icon_sizes_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Standard icon sizes used across the toolkit.
+
+/// Size presets for icons.
 class XIconSizesTokens extends Equatable {
   const XIconSizesTokens({
     double? extraSmall,

--- a/lib/src/base/tokens/geometry/x_layout_grid_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_layout_grid_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Grid configuration used for layout metrics.
+
+/// Defines the default layout grid for the application.
 class XLayoutGridTokens extends Equatable {
   const XLayoutGridTokens({
     int? columns,

--- a/lib/src/base/tokens/geometry/x_radii_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_radii_tokens.dart
@@ -1,5 +1,7 @@
 part of '../x_design_tokens.dart';
 
+/// Defines radius values and helpers to resolve them.
+
 enum XRadii {
   none,
   extraSmall,
@@ -26,6 +28,7 @@ enum XRadii {
   }
 }
 
+/// Radius presets used to build shapes and borders.
 class XRadiiTokens extends Equatable {
   const XRadiiTokens({
     double? extraSmall,

--- a/lib/src/base/tokens/geometry/x_spacings_tokens.dart
+++ b/lib/src/base/tokens/geometry/x_spacings_tokens.dart
@@ -1,5 +1,7 @@
 part of '../x_design_tokens.dart';
 
+/// Spacing scale used for margins, padding and gaps.
+
 enum XSpacings {
   none,
   superSmall,
@@ -28,6 +30,7 @@ enum XSpacings {
   }
 }
 
+/// Common spacing values following a 4 px scale.
 class XSpacingsTokens extends Equatable {
   const XSpacingsTokens({
     double? superSmall,

--- a/lib/src/base/tokens/painting/borders/border_radius/x_border_radius_resolver.dart
+++ b/lib/src/base/tokens/painting/borders/border_radius/x_border_radius_resolver.dart
@@ -1,5 +1,8 @@
 part of '../../../x_design_tokens.dart';
 
+/// Resolves [XBorderRadius] into Flutter [BorderRadius] values.
+
+/// Converts [XBorderRadius] definitions to concrete [BorderRadius] objects.
 class XBorderRadiusResolver extends Equatable {
   const XBorderRadiusResolver(this._radiiTokens);
   final XRadiiTokens _radiiTokens;

--- a/lib/src/base/tokens/painting/borders/input/x_input_border_resolver.dart
+++ b/lib/src/base/tokens/painting/borders/input/x_input_border_resolver.dart
@@ -1,5 +1,9 @@
 part of '../../../x_design_tokens.dart';
 
+/// Creates input borders based on tokenized radii values.
+
+/// Helper that builds [OutlineInputBorder] and [UnderlineInputBorder] using
+/// [XBorderRadius] tokens.
 class XInputBorderResolver extends Equatable {
   const XInputBorderResolver(this._radiiTokens);
   final XRadiiTokens _radiiTokens;

--- a/lib/src/base/tokens/painting/borders/input/x_outline_input_border.dart
+++ b/lib/src/base/tokens/painting/borders/input/x_outline_input_border.dart
@@ -29,7 +29,7 @@ class XOutlineInputBorder {
   /// The radii for each corner.
   final XBorderRadius borderRadius;
 
-  // TODO: description
+  /// Additional padding inserted at the gap of a floating label.
   final double gapPadding;
 
   /// Returns a copy of this XOutlineInputBorder with the given fields
@@ -42,10 +42,10 @@ class XOutlineInputBorder {
     );
   }
 
-  /// Converte um [XOutlineInputBorder] para um [OutlineInputBorder].
+  /// Converts an [XOutlineInputBorder] into an [OutlineInputBorder].
   ///
-  /// Retorna um [OutlineInputBorder] com a mesma configuração de [borderSide]
-  /// e [borderRadius].
+  /// Returns an [OutlineInputBorder] with the same [borderSide] and
+  /// [borderRadius] configuration.
   OutlineInputBorder toOutlineInputBorder(XRadiiTokens radiiTokens) {
     return OutlineInputBorder(
       borderSide: borderSide,

--- a/lib/src/base/tokens/painting/borders/input/x_underline_input_border.dart
+++ b/lib/src/base/tokens/painting/borders/input/x_underline_input_border.dart
@@ -38,10 +38,10 @@ class XUnderlineInputBorder {
     );
   }
 
-  /// Converte um [XUnderlineInputBorder] para um [UnderlineInputBorder].
+  /// Converts an [XUnderlineInputBorder] into an [UnderlineInputBorder].
   ///
-  /// Retorna um [UnderlineInputBorder] com a mesma configuração de [borderSide]
-  /// e [borderRadius].
+  /// Returns an [UnderlineInputBorder] with the same [borderSide] and
+  /// [borderRadius] configuration.
   UnderlineInputBorder toUnderlineInputBorder(XRadiiTokens radiiTokens) {
     return UnderlineInputBorder(
       borderSide: borderSide,

--- a/lib/src/base/tokens/painting/borders/radius/x_radius_resolver.dart
+++ b/lib/src/base/tokens/painting/borders/radius/x_radius_resolver.dart
@@ -1,5 +1,8 @@
 part of '../../../x_design_tokens.dart';
 
+/// Utility class for converting [XRadius] values to Flutter [Radius] objects.
+
+/// Resolves [XRadius] values using the provided [XRadiiTokens].
 class XRadiusResolver extends Equatable {
   const XRadiusResolver(this._radiiTokens);
   final XRadiiTokens _radiiTokens;

--- a/lib/src/base/tokens/painting/borders/shape/x_beveled_rectangle_border.dart
+++ b/lib/src/base/tokens/painting/borders/shape/x_beveled_rectangle_border.dart
@@ -38,10 +38,10 @@ class XBeveledRectangleBorder {
     );
   }
 
-  /// Converte um [XBeveledRectangleBorder] para um [BeveledRectangleBorder].
+  /// Converts an [XBeveledRectangleBorder] into a [BeveledRectangleBorder].
   ///
-  /// Retorna um [BeveledRectangleBorder] com a mesma configuração de [borderSide]
-  /// e [borderRadius].
+  /// Returns a [BeveledRectangleBorder] with the same [borderSide] and
+  /// [borderRadius] configuration.
   BeveledRectangleBorder toBeveledRectangleBorder(XRadiiTokens radiiTokens) {
     return BeveledRectangleBorder(
       side: borderSide,

--- a/lib/src/base/tokens/painting/borders/shape/x_continuous_rectangle_border.dart
+++ b/lib/src/base/tokens/painting/borders/shape/x_continuous_rectangle_border.dart
@@ -38,10 +38,10 @@ class XContinuousRectangleBorder {
     );
   }
 
-  /// Converte um [XContinuousRectangleBorder] para um [ContinuousRectangleBorder].
+  /// Converts an [XContinuousRectangleBorder] into a [ContinuousRectangleBorder].
   ///
-  /// Retorna um [ContinuousRectangleBorder] com a mesma configuração de [borderSide]
-  /// e [borderRadius].
+  /// Returns a [ContinuousRectangleBorder] with the same [borderSide] and
+  /// [borderRadius] configuration.
   ContinuousRectangleBorder toContinuousRectangleBorder(
       XRadiiTokens radiiTokens) {
     return ContinuousRectangleBorder(

--- a/lib/src/base/tokens/painting/borders/shape/x_rounded_rectangle_border.dart
+++ b/lib/src/base/tokens/painting/borders/shape/x_rounded_rectangle_border.dart
@@ -38,10 +38,10 @@ class XRoundedRectangleBorder {
     );
   }
 
-  /// Converte um [XRoundedRectangleBorder] para um [RoundedRectangleBorder].
+  /// Converts an [XRoundedRectangleBorder] into a [RoundedRectangleBorder].
   ///
-  /// Retorna um [RoundedRectangleBorder] com a mesma configuração de [borderSide]
-  /// e [borderRadius].
+  /// Returns a [RoundedRectangleBorder] with the same [borderSide] and
+  /// [borderRadius] configuration.
   RoundedRectangleBorder toRoundedRectangleBorder(XRadiiTokens radiiTokens) {
     return RoundedRectangleBorder(
       side: borderSide,

--- a/lib/src/base/tokens/painting/borders/shape/x_shape_resolver.dart
+++ b/lib/src/base/tokens/painting/borders/shape/x_shape_resolver.dart
@@ -1,5 +1,8 @@
 part of '../../../x_design_tokens.dart';
 
+/// Provides convenience methods for creating border shapes using [XRadiiTokens].
+
+/// Builds Flutter shapes from [XBorderRadius] definitions.
 class XShapeResolver extends Equatable {
   const XShapeResolver(this._radiiTokens);
   final XRadiiTokens _radiiTokens;

--- a/lib/src/base/tokens/painting/edge_insets/x_edge_insets_resolver.dart
+++ b/lib/src/base/tokens/painting/edge_insets/x_edge_insets_resolver.dart
@@ -1,5 +1,8 @@
 part of '../../x_design_tokens.dart';
 
+/// Converts [XSpacings] values into Flutter [EdgeInsets].
+
+/// Helper that maps spacing tokens to [EdgeInsets] instances.
 class XEdgeInsetsResolver extends Equatable {
   const XEdgeInsetsResolver(this._spacings);
   final XSpacingsTokens _spacings;

--- a/lib/src/base/tokens/painting/edge_insets/x_padding_resolver.dart
+++ b/lib/src/base/tokens/painting/edge_insets/x_padding_resolver.dart
@@ -1,5 +1,8 @@
 part of '../../x_design_tokens.dart';
 
+/// Convenience builder for [Padding] widgets based on spacing tokens.
+
+/// Generates [Padding] widgets using [XEdgeInsetsResolver].
 class XPaddingResolver extends Equatable {
   const XPaddingResolver(this._edgeInsets);
   final XEdgeInsetsResolver _edgeInsets;

--- a/lib/src/base/tokens/painting/x_box_shadows_tokens.dart
+++ b/lib/src/base/tokens/painting/x_box_shadows_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Box shadow presets used by components.
+
+/// Predefined [BoxShadow] values for different elevation levels.
 class XBoxShadowsTokens extends Equatable {
   const XBoxShadowsTokens({
     BoxShadow? small,

--- a/lib/src/base/tokens/painting/x_gaps_resolver.dart
+++ b/lib/src/base/tokens/painting/x_gaps_resolver.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Creates [Gap] widgets based on spacing tokens.
+
+/// Utility for generating consistent gaps between widgets.
 class XGapsResolver extends Equatable {
   const XGapsResolver(this._spacings);
   final XSpacingsTokens _spacings;

--- a/lib/src/base/tokens/painting/x_google_fonts_tokens.dart
+++ b/lib/src/base/tokens/painting/x_google_fonts_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Helper for accessing fonts from the Google Fonts package.
+
+/// Provides utilities for retrieving Google Fonts and their names.
 class XGoogleFontsTokens extends Equatable {
   const XGoogleFontsTokens();
 

--- a/lib/src/base/tokens/painting/x_opacities_tokens.dart
+++ b/lib/src/base/tokens/painting/x_opacities_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Opacity values used for interactive states.
+
+/// Defines opacity values for different component states.
 class XOpacitiesTokens extends Equatable {
   const XOpacitiesTokens({
     double? disabled,

--- a/lib/src/base/tokens/painting/x_text_shadows_tokens.dart
+++ b/lib/src/base/tokens/painting/x_text_shadows_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Shadow presets for text elements.
+
+/// Predefined [Shadow] values used for text.
 class XTextShadowsTokens extends Equatable {
   const XTextShadowsTokens({
     Shadow? small,

--- a/lib/src/base/tokens/painting/x_z_indexes_tokens.dart
+++ b/lib/src/base/tokens/painting/x_z_indexes_tokens.dart
@@ -1,5 +1,8 @@
 part of '../x_design_tokens.dart';
 
+/// Z-index values defining the stacking order of components.
+
+/// Defines the stacking order for widgets using integer z-indexes.
 class XZIndexesTokens extends Equatable {
   const XZIndexesTokens({
     int? background,

--- a/lib/src/base/tokens/x_design_tokens.dart
+++ b/lib/src/base/tokens/x_design_tokens.dart
@@ -1,3 +1,4 @@
+/// Core design token definitions for the Material Toolkit package.
 library;
 
 import 'dart:convert';
@@ -37,6 +38,7 @@ part 'painting/x_opacities_tokens.dart';
 part 'painting/x_text_shadows_tokens.dart';
 part 'painting/x_z_indexes_tokens.dart';
 
+/// Provides [XDesignTokens] to the widget tree via an [InheritedWidget].
 class XDesign extends InheritedWidget {
   const XDesign({required super.child, required this.tokens, super.key});
 
@@ -59,6 +61,11 @@ class XDesign extends InheritedWidget {
   bool updateShouldNotify(XDesign oldWidget) => tokens != oldWidget.tokens;
 }
 
+/// Collection of design tokens used throughout the application.
+///
+/// Each group of tokens holds values for a specific aspect of the UI, such as
+/// spacing or typography. These tokens can be overridden using [copyWith] or
+/// [XDesignTokens.material].
 class XDesignTokens extends ThemeExtension<XDesignTokens> {
   XDesignTokens({
     this.boxShadows = const XBoxShadowsTokens(),


### PR DESCRIPTION
## Summary
- add detailed comments to helper utilities
- document design token classes and resolvers
- replace Portuguese comments with English descriptions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717bb960e08322a1a9a9ee2620e959